### PR TITLE
[squid:S2583] Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/app/src/main/java/io/apptik/multiview/common/IOUtils.java
+++ b/app/src/main/java/io/apptik/multiview/common/IOUtils.java
@@ -55,7 +55,7 @@ public class IOUtils {
 	public static void closeSilently( Cursor cursor ) {
 		if ( cursor == null ) return;
 		try {
-			if ( cursor != null ) cursor.close();
+			cursor.close();
 		} catch ( Throwable t ) {}
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2583 - “Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2583

Please let me know if you have any questions.
Ayman Abdelghany.
