### PR TITLE
[squid:UselessParenthesesCheck] Useless parentheses around expressions should be removed

### DIFF
--- a/layoutmanagers/src/main/java/io/apptik/multiview/layoutmanagers/AbstractPagerLLM.java
+++ b/layoutmanagers/src/main/java/io/apptik/multiview/layoutmanagers/AbstractPagerLLM.java
@@ -168,7 +168,7 @@ public class AbstractPagerLLM<T extends AbstractPagerLLM<T>> extends AbstractSna
             return;
         }
 
-        if ((smoothScroller != null && (smoothScroller.isRunning())) || isSmoothScrolling()) {
+        if ((smoothScroller != null && smoothScroller.isRunning()) || isSmoothScrolling()) {
             Log.d("already scrolling");
             return;
         }

--- a/layoutmanagers/src/main/java/io/apptik/multiview/layoutmanagers/AbstractSnapperLLM.java
+++ b/layoutmanagers/src/main/java/io/apptik/multiview/layoutmanagers/AbstractSnapperLLM.java
@@ -199,7 +199,7 @@ public abstract class AbstractSnapperLLM<T extends AbstractSnapperLLM<T>> extend
             return;
         }
 
-        if ((smoothScroller != null && (smoothScroller.isRunning())) || isSmoothScrolling()) {
+        if ((smoothScroller != null && smoothScroller.isRunning()) || isSmoothScrolling()) {
             Log.d("already scrolling");
             return;
         }

--- a/scalablerecyclerview/src/main/java/io/apptik/multiview/scalablerecyclerview/BaseGridScaler.java
+++ b/scalablerecyclerview/src/main/java/io/apptik/multiview/scalablerecyclerview/BaseGridScaler.java
@@ -100,14 +100,14 @@ public abstract class BaseGridScaler implements GridScaler {
 
         @Override
         public boolean onSingleTapConfirmed(MotionEvent e) {
-            Log.d("onSingleTapConfirmed: " + ((e == null) ? "e==null" : e.getX() + "/" + e.getY()));
+            Log.d("onSingleTapConfirmed: " + (e == null ? "e==null" : e.getX() + "/" + e.getY()));
             if (scaleGestureDetector.isInProgress()) return true;
             return false;
         }
 
         @Override
         public boolean onDoubleTap(MotionEvent e) {
-            Log.d("onDoubleTap: " + ((e == null) ? "e==null" : e.getX() + "/" + e.getY()) + " v: " + currentView);
+            Log.d("onDoubleTap: " + (e == null ? "e==null" : e.getX() + "/" + e.getY()) + " v: " + currentView);
             if (scaleGestureDetector.isInProgress()) return false;
             //toggle min/max col span for grid mode
 
@@ -130,7 +130,7 @@ public abstract class BaseGridScaler implements GridScaler {
 
         @Override
         public boolean onDoubleTapEvent(MotionEvent e) {
-            Log.d("onDoubleTapEvent: " + ((e == null) ? "e==null" : e.getX() + "/" + e.getY()));
+            Log.d("onDoubleTapEvent: " + (e == null ? "e==null" : e.getX() + "/" + e.getY()));
             if (scaleGestureDetector.isInProgress()) return false;
             //TODO do we ?
             //not in use now but we have to return true
@@ -139,33 +139,33 @@ public abstract class BaseGridScaler implements GridScaler {
 
         @Override
         public boolean onDown(MotionEvent e) {
-            Log.d("onDown: " + ((e == null) ? "e==null" : e.getX() + "/" + e.getY()));
+            Log.d("onDown: " + (e == null ? "e==null" : e.getX() + "/" + e.getY()));
             return false;
         }
 
         @Override
         public void onShowPress(MotionEvent e) {
-            Log.d("onShowPress: " + ((e == null) ? "e==null" : e.getX() + "/" + e.getY()));
+            Log.d("onShowPress: " + (e == null ? "e==null" : e.getX() + "/" + e.getY()));
             //just ignore
         }
 
         @Override
         public boolean onSingleTapUp(MotionEvent e) {
-            Log.d("onSingleTapUp: " + ((e == null) ? "e==null" : e.getX() + "/" + e.getY()));
+            Log.d("onSingleTapUp: " + (e == null ? "e==null" : e.getX() + "/" + e.getY()));
             if (scaleGestureDetector.isInProgress()) return true;
             return false;
         }
 
         @Override
         public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
-            Log.d("onScroll: " + ((e1 == null) ? "e1==null" : e1.getX() + "/" + e1.getY()) + " - " + ((e2 == null) ? "e2==null" : e2.getX() + "/" + e2.getY()) + " :: " + distanceX + "/" + distanceY);
+            Log.d("onScroll: " + (e1 == null ? "e1==null" : e1.getX() + "/" + e1.getY()) + " - " + (e2 == null ? "e2==null" : e2.getX() + "/" + e2.getY()) + " :: " + distanceX + "/" + distanceY);
             if (scaleGestureDetector.isInProgress()) return true;
             return false;
         }
 
         @Override
         public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
-            Log.d("onFling: " + ((e1 == null) ? "e1==null" : e1.getX() + "/" + e1.getY()) + " - " + ((e2 == null) ? "e2==null" : e2.getX() + "/" + e2.getY()) + " :: " + velocityX + "/" + velocityY);
+            Log.d("onFling: " + (e1 == null ? "e1==null" : e1.getX() + "/" + e1.getY()) + " - " + (e2 == null ? "e2==null" : e2.getX() + "/" + e2.getY()) + " :: " + velocityX + "/" + velocityY);
             if (scaleGestureDetector.isInProgress()) return true;
             return false;
         }
@@ -173,7 +173,7 @@ public abstract class BaseGridScaler implements GridScaler {
 
         @Override
         public void onLongPress(MotionEvent e) {
-            Log.d("onLongPress: " + ((e == null) ? "e==null" : e.getX() + "/" + e.getY()));
+            Log.d("onLongPress: " + (e == null ? "e==null" : e.getX() + "/" + e.getY()));
             //maybe menu
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.
Ayman Abdelghany.
