### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/io/apptik/multiview/common/BitmapUtils.java
+++ b/app/src/main/java/io/apptik/multiview/common/BitmapUtils.java
@@ -27,6 +27,9 @@ import android.graphics.Matrix;
  */
 public class BitmapUtils {
 
+	private BitmapUtils() {
+	}
+
 	/**
 	 * Resize a bitmap
 	 * 

--- a/app/src/main/java/io/apptik/multiview/common/DecodeUtils.java
+++ b/app/src/main/java/io/apptik/multiview/common/DecodeUtils.java
@@ -32,6 +32,9 @@ import java.net.MalformedURLException;
 
 public class DecodeUtils {
 
+	private DecodeUtils() {
+	}
+
 	/**
 	 * Try to load a {@link Bitmap} from the passed {@link Uri} ( a file, a content or an url )
 	 * 

--- a/app/src/main/java/io/apptik/multiview/common/ExifUtils.java
+++ b/app/src/main/java/io/apptik/multiview/common/ExifUtils.java
@@ -37,6 +37,9 @@ public class ExifUtils {
 		ExifInterface.TAG_IMAGE_WIDTH, "ISOSpeedRatings", ExifInterface.TAG_MAKE, ExifInterface.TAG_MODEL,
 		ExifInterface.TAG_WHITE_BALANCE, };
 
+	private ExifUtils() {
+	}
+
 	/**
 	 * Return the rotation of the passed image file
 	 * 

--- a/app/src/main/java/io/apptik/multiview/common/IOUtils.java
+++ b/app/src/main/java/io/apptik/multiview/common/IOUtils.java
@@ -33,6 +33,9 @@ import java.io.Closeable;
  */
 public class IOUtils {
 
+	private IOUtils() {
+	}
+
 	/**
 	 * Close a {@link Closeable} stream without throwing any exception
 	 * 

--- a/extras/src/main/java/io/apptik/multiview/extras/ViewUtils.java
+++ b/extras/src/main/java/io/apptik/multiview/extras/ViewUtils.java
@@ -24,6 +24,9 @@ import android.view.View;
 public class ViewUtils {
 
 
+    private ViewUtils() {
+    }
+
     /**
      * Get center child in X Axes
      */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
