### PR TITLE
[squid:UselessImportCheck] Useless imports should be removed

### DIFF
--- a/decorations/src/main/java/io/apptik/multiview/decorations/GridDividerDecoration.java
+++ b/decorations/src/main/java/io/apptik/multiview/decorations/GridDividerDecoration.java
@@ -16,14 +16,11 @@
 
 package io.apptik.multiview.decorations;
 
-import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.ItemDecoration;
-import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup.MarginLayoutParams;
 

--- a/decorations/src/main/java/io/apptik/multiview/decorations/GridSpacingDecoration.java
+++ b/decorations/src/main/java/io/apptik/multiview/decorations/GridSpacingDecoration.java
@@ -18,11 +18,9 @@ package io.apptik.multiview.decorations;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.content.res.TypedArray;
 import android.graphics.Rect;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.ItemDecoration;
-import android.util.AttributeSet;
 
 
 public class GridSpacingDecoration extends ItemDecoration {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessImportCheck - “Useless imports should be removed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck

Please let me know if you have any questions.
Ayman Abdelghany.
