### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the correct order

### DIFF
--- a/decorations/src/main/java/io/apptik/multiview/decorations/GridSpacingDecoration.java
+++ b/decorations/src/main/java/io/apptik/multiview/decorations/GridSpacingDecoration.java
@@ -26,7 +26,7 @@ import android.util.AttributeSet;
 
 
 public class GridSpacingDecoration extends ItemDecoration {
-    public final static int DEFAULT_PADDING = 8;
+    public static final int DEFAULT_PADDING = 8;
     private int mPaddingPx = 8;
     private int mPaddingEdgesPx = 16;
 

--- a/decorations/src/main/java/io/apptik/multiview/decorations/ListSpacingDecoration.java
+++ b/decorations/src/main/java/io/apptik/multiview/decorations/ListSpacingDecoration.java
@@ -26,7 +26,7 @@ import android.view.View;
 
 
 public class ListSpacingDecoration extends RecyclerView.ItemDecoration {
-    public final static int DEFAULT_PADDING = 8;
+    public static final int DEFAULT_PADDING = 8;
     private int mPaddingPx = 8;
     private int mPaddingEdgesPx = 16;
 

--- a/scalablerecyclerview/src/main/java/io/apptik/multiview/scalablerecyclerview/BaseGridScaler.java
+++ b/scalablerecyclerview/src/main/java/io/apptik/multiview/scalablerecyclerview/BaseGridScaler.java
@@ -68,7 +68,7 @@ public abstract class BaseGridScaler implements GridScaler {
         volatile int initSpanCount = 0;
         volatile View currentView;
         //used to normalise the raw factor when scaling in not allowed direction
-        volatile private float factorOffset;
+        private volatile float factorOffset;
 
         public InteractionListener(RecyclerView recyclerView) {
             this.recyclerView = recyclerView;

--- a/scalablerecyclerview/src/main/java/io/apptik/multiview/scalablerecyclerview/ScalableRecyclerGridView.java
+++ b/scalablerecyclerview/src/main/java/io/apptik/multiview/scalablerecyclerview/ScalableRecyclerGridView.java
@@ -207,7 +207,7 @@ public class ScalableRecyclerGridView extends RecyclerView {
         volatile int initSpanCount = 0;
         volatile View currentView;
         //used to normalise the raw factor when scaling in not allowed direction
-        volatile private float factorOffset;
+        private volatile float factorOffset;
 
         public InteractionListener(Context context, ScalableRecyclerGridView scalableRecyclerGridView) {
             this.context = context;

--- a/scrollers/src/main/java/io/apptik/multiview/scrollers/BaseSmoothScroller.java
+++ b/scrollers/src/main/java/io/apptik/multiview/scrollers/BaseSmoothScroller.java
@@ -477,5 +477,5 @@ public abstract class BaseSmoothScroller extends RecyclerView.SmoothScroller {
         return calculateDtToFit(left, right, start, end, snapPreference);
     }
 
-    abstract public PointF computeScrollVectorForPosition(int targetPosition);
+    public abstract PointF computeScrollVectorForPosition(int targetPosition);
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Ayman Abdelghany.
