### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Multi-purpose Android UI components based on RecyclerView
 
-##Download
+## Download
 
 Find [the latest JARs][mvn] or grab via Maven:
 ```xml

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,6 +1,6 @@
-#Adapters for RecyclerView
+# Adapters for RecyclerView
 
-##Download
+## Download
 
 Download [the latest JAR][mvn] or grab via Maven:
 ```xml

--- a/animators/README.md
+++ b/animators/README.md
@@ -1,6 +1,6 @@
-#Animators for RecyclerView
+# Animators for RecyclerView
 
-##Download
+## Download
 
 Download [the latest JAR][mvn] or grab via Maven:
 ```xml

--- a/common/README.md
+++ b/common/README.md
@@ -1,6 +1,6 @@
-#Common tools for RecyclerView
+# Common tools for RecyclerView
 
-##Download
+## Download
 
 Download [the latest JAR][mvn] or grab via Maven:
 ```xml

--- a/decorations/README.md
+++ b/decorations/README.md
@@ -1,6 +1,6 @@
-#Decorations for RecyclerView
+# Decorations for RecyclerView
 
-##Download
+## Download
 
 Download [the latest JAR][mvn] or grab via Maven:
 ```xml

--- a/extras/README.md
+++ b/extras/README.md
@@ -1,6 +1,6 @@
-#Extra hooks for RecyclerView
+# Extra hooks for RecyclerView
 
-##Download
+## Download
 
 Download [the latest JAR][mvn] or grab via Maven:
 ```xml

--- a/galleryview/README.md
+++ b/galleryview/README.md
@@ -1,6 +1,6 @@
-#Galleryview based on RecyclerView
+# Galleryview based on RecyclerView
 
-##Download
+## Download
 
 Download [the latest JAR][mvn] or grab via Maven:
 ```xml

--- a/layoutmanagers/README.md
+++ b/layoutmanagers/README.md
@@ -1,6 +1,6 @@
-#Layoutmanagers for RecyclerView
+# Layoutmanagers for RecyclerView
 
-##Download
+## Download
 
 Download [the latest JAR][mvn] or grab via Maven:
 ```xml

--- a/scalablerecyclerview/README.md
+++ b/scalablerecyclerview/README.md
@@ -1,6 +1,6 @@
-#Scalablerecyclerview based on RecyclerView
+# Scalablerecyclerview based on RecyclerView
 
-##Download
+## Download
 
 Download [the latest JAR][mvn] or grab via Maven:
 ```xml

--- a/scrollers/README.md
+++ b/scrollers/README.md
@@ -1,6 +1,6 @@
-#Scrollers for RecyclerView
+# Scrollers for RecyclerView
 
-##Download
+## Download
 
 Download [the latest JAR][mvn] or grab via Maven:
 ```xml


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
